### PR TITLE
Fix tiny Rubberduckies URL typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
 **Read this program's postmortem at my [blog](http://konukoii.com/blog/2016/10/26/duckhunting-stopping-automated-keystroke-injection-attacks/)**
 <h3>Intro</h3>
+
 [Rubberduckies](https://hakshop.myshopify.com/products/usb-rubber-ducky-deluxe) are small usb devices that pretend to be usb keyboards and can type on their own at very high speeds. Because most -if not all- OS trust keyboards automatically, it is hard to protect oneself from these attacks.
 
 **DuckHunt** is a small efficient script that acts as a daemon consistently monitoring your keyboard usage (right now, speed and selected window) that can catch and prevent a rubber ducky attack. (Technically it helps prevent any type of automated keystroke injection attack, so things like Mousejack injections are also covered.)


### PR DESCRIPTION
I was looking for Python projects that use the 'keyboard' library, and I happened to stumble on this one. While looking at it, I couldn't help but notice the small URL typo in the README and the fact that it could be fixed with one blank line.